### PR TITLE
Make the night choices a fake prompt

### DIFF
--- a/mafia-conversation-bot/AdaptiveCardPrompt.cs
+++ b/mafia-conversation-bot/AdaptiveCardPrompt.cs
@@ -28,8 +28,10 @@ namespace Bot.AdaptiveCard.Prompt
                 throw new ArgumentException(nameof(options));
             }
 
+            
             if (isRetry && options.Prompt != null)
             {
+                if (options.RetryPrompt != null)
                 await turnContext.SendActivityAsync(options.RetryPrompt, cancellationToken).ConfigureAwait(false);
             }
             else if (options.Prompt != null)
@@ -56,13 +58,13 @@ namespace Bot.AdaptiveCard.Prompt
             {
                 if (turnContext.Activity.Value != null)
                 {
-                    if (turnContext.Activity.Value is JObject)
+                    Console.WriteLine("++++++++++++Recognize++++++" + turnContext.Activity.Value.ToString());
+                    if (turnContext.Activity.Value is JObject && turnContext.Activity.Value.ToString().Contains("_choice"))
                     {
                         result.Value = turnContext.Activity.Value as JObject;
                         result.Succeeded = true;
                     }
                 }
-
             }
 
             return Task.FromResult(result);

--- a/mafia-conversation-bot/Bots/DialogAndWelcome.cs
+++ b/mafia-conversation-bot/Bots/DialogAndWelcome.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,8 +15,14 @@ namespace Microsoft.BotBuilderSamples
 {
     public class DialogAndWelcomeBot<T> : DialogBot<T> where T : Dialog
     {
-        public DialogAndWelcomeBot(IConfiguration config, ConversationState conversationState, UserState userState, T dialog, ILogger<DialogBot<T>> logger)
-            : base(config, conversationState, userState, dialog, logger)
+        public DialogAndWelcomeBot(
+            IConfiguration config,
+            ConversationState conversationState,
+            UserState userState,
+            T dialog,
+            ILogger<DialogBot<T>> logger,
+            ConcurrentDictionary<string, ConversationReference> conversationReferences)
+            : base(config, conversationState, userState, dialog, logger, conversationReferences)
         {
         }
 

--- a/mafia-conversation-bot/Bots/DialogBot.cs
+++ b/mafia-conversation-bot/Bots/DialogBot.cs
@@ -96,6 +96,7 @@ namespace Microsoft.BotBuilderSamples
                         convInfo.DoctorTarget = (string)(activityValue as JObject)["doctor_choice"];
 
                     List<string> doctorIdList = convInfo.RoleToUsers.GetValueOrDefault(Role.Doctor.ToString(), new List<string>());
+                    // If doctor is dead
                     if (doctorIdList.Any())
                         isNightChoiceIncomplete &= !(convInfo.MafiaTarget != null && convInfo.DoctorTarget != null);
                     else
@@ -107,12 +108,12 @@ namespace Microsoft.BotBuilderSamples
                 if (isNightChoiceIncomplete)
                 {
                     await turnContext.SendActivityAsync("Still waiting for some role to choose!");
-                    // convInfo.DoctorTarget = "No one";
-                    // await Dialog.RunAsync(turnContext, ConversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
+                    convInfo.DoctorTarget = "No one";
+                    await Dialog.RunAsync(turnContext, ConversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
                 }
                 else
                 {
-                    Logger.LogInformation("-----Converation Data. mafia target: {0}, doctor target: {1} -----\n",
+                    Logger.LogInformation("===========Converation Data. mafia target: {0}, doctor target: {1} ======\n",
                         convInfo.MafiaTarget, convInfo.DoctorTarget);
                     await Dialog.RunAsync(turnContext, ConversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
                 }

--- a/mafia-conversation-bot/Bots/DialogBot.cs
+++ b/mafia-conversation-bot/Bots/DialogBot.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MafiaCore;
@@ -12,6 +14,7 @@ using Microsoft.Bot.Builder.Teams;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -29,8 +32,16 @@ namespace Microsoft.BotBuilderSamples
         protected readonly Dialog Dialog;
         protected readonly ILogger Logger;
         protected readonly BotState UserState;
+        protected readonly ConcurrentDictionary<string, ConversationReference> _conversationReferences;
 
-        public DialogBot(IConfiguration config, ConversationState conversationState, UserState userState, T dialog, ILogger<DialogBot<T>> logger)
+        public DialogBot(
+            IConfiguration config,
+            ConversationState conversationState,
+            UserState userState,
+            T dialog,
+            ILogger<DialogBot<T>> logger,
+            ConcurrentDictionary<string, ConversationReference> conversationReferences
+            )
         {
             _appId = config["MicrosoftAppId"];
             _appPassword = config["MicrosoftAppPassword"];
@@ -38,12 +49,51 @@ namespace Microsoft.BotBuilderSamples
             UserState = userState;
             Dialog = dialog;
             Logger = logger;
+            _conversationReferences = conversationReferences;
+        }
+
+        private void AddConversationReference(Activity activity)
+        {
+            var conversationReference = activity.GetConversationReference();
+            _conversationReferences.AddOrUpdate(conversationReference.Conversation.Id, conversationReference, (key, newValue) => conversationReference);
+        }
+
+        protected override Task OnConversationUpdateActivityAsync(ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
+        {
+            AddConversationReference(turnContext.Activity as Activity);
+            Logger.LogInformation("-----ConverSation ADDDDDDD. Id: {0}, name: {1}, conversaton: {2} -----\n",
+                turnContext.Activity.From.Id, turnContext.Activity.From.Name, Tuple.Create(turnContext.Activity.Conversation.Name, turnContext.Activity.Conversation.Id));
+
+            return base.OnConversationUpdateActivityAsync(turnContext, cancellationToken);
         }
 
         public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Logger.LogInformation("======Activity Type: {0}, Text: {1} =========\n", turnContext.Activity.Type, turnContext.Activity.Text);
+            Logger.LogInformation("======Activity Type: {0}, Text: {1}, Channel: {2}=========\n", turnContext.Activity.Type, turnContext.Activity.Text, turnContext.Activity.ChannelId);
             await base.OnTurnAsync(turnContext, cancellationToken);
+
+            if (turnContext.Activity.Type == ActivityTypes.Event)
+            {
+                /*
+                var dialogState = ConversationState.CreateProperty<DialogState>("DialogState");
+                var dialogs = new DialogSet(dialogState);
+                var dc = await dialogs.CreateContextAsync(turnContext);
+                DialogSet test = dc.Dialogs;
+                if (dc.ActiveDialog == null)
+                {
+                    await dc.BeginDialogAsync(nameof(MainDialog), cancellationToken);
+                }
+                else
+                {
+                    await dc.ContinueDialogAsync(cancellationToken);
+                }
+                */
+
+                // var convStateAccessor = ConversationState.CreateProperty<ConversationData>(nameof(ConversationData));
+                // var convInfo = await convStateAccessor.GetAsync(turnContext, () => new ConversationData());
+                // convInfo.MafiaTarget = "29:1wCyJavZQMtos86UTKyTR_P1lMi7PAXRtz3fPQaTQPEiJJ0wy_0xx2xsQHoFc3nBY-52tzcsKUiKdlSyoSNxu6A";
+                await Dialog.RunAsync(turnContext, ConversationState.CreateProperty<DialogState>(nameof(DialogState)), cancellationToken);
+            }
 
             // Save any state changes that might have occurred during the turn.
             await ConversationState.SaveChangesAsync(turnContext, false, cancellationToken);
@@ -53,6 +103,7 @@ namespace Microsoft.BotBuilderSamples
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
             turnContext.Activity.RemoveRecipientMention();
+            AddConversationReference(turnContext.Activity as Activity);
 
             var userStateAccessor = UserState.CreateProperty<UserProfile>(nameof(UserProfile));
             var userInfo = await userStateAccessor.GetAsync(turnContext, () => new UserProfile());
@@ -60,7 +111,14 @@ namespace Microsoft.BotBuilderSamples
             var convStateAccessor = ConversationState.CreateProperty<ConversationData>(nameof(ConversationData));
             var convInfo = await convStateAccessor.GetAsync(turnContext, () => new ConversationData());
 
+            // Exclude the scenario where players start the game by clicking the choicepromp afterwards
+            if (!convInfo.IsGameStarted && turnContext.Activity.Value != null)
+            {
+                return;
+            }
+
             bool isActiveMafia = false;
+            bool isNightChoiceIncomplete = false;
             List<string> mafiaIdList = convInfo.RoleToUsers.GetValueOrDefault(Role.Mafia.ToString(), new List<string>());
             if (string.IsNullOrEmpty(userInfo.Id))
             {
@@ -75,16 +133,39 @@ namespace Microsoft.BotBuilderSamples
             }
             userInfo.IsActive = convInfo.ActivePlayers.Contains(userInfo.Id);
             isActiveMafia &= userInfo.IsActive;
-
-            Logger.LogInformation("-----Message Activity. Id: {0}, name: {1}, conversaton: {2} -----\n",
-                turnContext.Activity.From.Id, turnContext.Activity.From.Name, Tuple.Create(turnContext.Activity.Conversation.Name, turnContext.Activity.Conversation.Id));
-            Logger.LogInformation("-----User Profile. Id: {0}, name: {1}, email: {2}, isActive: {3} -----\n", userInfo.Id, userInfo.Name, userInfo.Email, userInfo.IsActive);
-            Logger.LogInformation("-----Converation Data. mafia members: {0} -----\n", string.Join(" + ", mafiaIdList));
-
-            // Run the Dialog with the new message Activity.
-            var isMissChose = turnContext.Activity.Value != null && 
+            var isMissChose = turnContext.Activity.Value != null &&
                 turnContext.Activity.Value.ToString().Contains("kill_choice") &&
                 !isActiveMafia;
+
+            // update the killtarget and other targets in conversation state
+            // It's not used for vote_choice in Daytime currently
+            // If doctor or detective get killed, just update the 
+            if (turnContext.Activity.Value != null &&
+                turnContext.Activity.Value is JObject)
+            {
+                var activityValue = turnContext.Activity.Value;
+                if (activityValue.ToString().Contains("kill_choice") || activityValue.ToString().Contains("doctor_choice"))
+                    isNightChoiceIncomplete = true;
+
+                if (activityValue.ToString().Contains("kill_choice"))
+                    convInfo.MafiaTarget = (string)(activityValue as JObject)["kill_choice"];
+                else if (activityValue.ToString().Contains("doctor_choice"))
+                    convInfo.DoctorTarget = (string)(activityValue as JObject)["doctor_choice"];
+
+                isNightChoiceIncomplete &= !(convInfo.MafiaTarget != null && convInfo.DoctorTarget != null);
+            }
+
+            Logger.LogInformation("-----Message Activity. Id: {0}, name: {1}, conversaton: {2}, \t------ conversation count: {3} -----\n",
+                turnContext.Activity.From.Id,
+                turnContext.Activity.From.Name,
+                Tuple.Create(turnContext.Activity.Conversation.Name,
+                turnContext.Activity.Conversation.Id),
+                string.Join(", ", _conversationReferences.Select(c => $"[{c.Key} -*- {c.Value.Conversation.Name}]")));
+            Logger.LogInformation("-----User Profile. Id: {0}, name: {1}, email: {2}, isActive: {3} -----\n", userInfo.Id, userInfo.Name, userInfo.Email, userInfo.IsActive);
+            Logger.LogInformation("-----Converation Data. mafia members: {0}, mafia target: {1}, doctor target: {2} -----\n",
+                string.Join(" + ", mafiaIdList), convInfo.MafiaTarget, convInfo.DoctorTarget);
+
+            // Logic of deciding when to start the dialog
             if (!userInfo.IsActive && convInfo.IsGameStarted)
             {
                 await turnContext.SendActivityAsync("Sorry, you are dead. Please try not doing any operation.");
@@ -92,6 +173,10 @@ namespace Microsoft.BotBuilderSamples
             else if (isMissChose)
             {
                 await turnContext.SendActivityAsync("Only Mafia should decide who to kill!");
+            }
+            else if (isNightChoiceIncomplete)
+            {
+                await turnContext.SendActivityAsync("Still waiting for some role to choose!");
             }
             else
             {

--- a/mafia-conversation-bot/Controllers/BotController.cs
+++ b/mafia-conversation-bot/Controllers/BotController.cs
@@ -70,6 +70,17 @@ namespace Microsoft.BotBuilderSamples
             var activity = await HttpHelper.ReadRequestAsync<Activity>(Request);
 
             // Redirect the reply to the game chat
+            if (activity.Value != null && activity.Value is JObject)
+            {
+                var currentConvRef = activity.GetConversationReference();
+                await ((BotFrameworkAdapter)_adapter).ContinueConversationAsync(_appId, currentConvRef, async (context, token) =>
+                {
+                    await context.DeleteActivityAsync(activity.ReplyToId, token);
+                    await context.SendActivityAsync("Thanks for your choice! Let's see if it can finish the game ......");
+
+                }, default(CancellationToken));
+            }
+
             if (activity.Value != null && activity.Value is JObject && activity.Value.ToString().Contains("SendbackTo"))
             {
                 _conversations.TryGetValue((string)(activity.Value as JObject)["SendbackTo"], out ConversationReference convRef);

--- a/mafia-conversation-bot/Controllers/BotController.cs
+++ b/mafia-conversation-bot/Controllers/BotController.cs
@@ -1,35 +1,78 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.BotBuilderSamples
 {
     // This ASP Controller is created to handle a request. Dependency Injection will provide the Adapter and IBot
     // implementation at runtime. Multiple different IBot implementations running at different endpoints can be
     // achieved by specifying a more specific type for the bot constructor argument.
-    [Route("api/messages")]
     [ApiController]
     public class BotController : ControllerBase
     {
         private readonly IBotFrameworkHttpAdapter _adapter;
         private readonly IBot _bot;
+        private readonly ILogger<BotController> _logger;
+        private readonly ConcurrentDictionary<string, ConversationReference> _conversations;
+        private readonly string _appId;
 
-        public BotController(IBotFrameworkHttpAdapter adapter, IBot bot)
+        public BotController(
+            IBotFrameworkHttpAdapter adapter,
+            IBot bot, ILogger<BotController> logger,
+            ConcurrentDictionary<string, ConversationReference> conversationReferences,
+            IConfiguration configuration
+            )
         {
             _adapter = adapter;
             _bot = bot;
+            _logger = logger;
+            _conversations = conversationReferences;
+            _appId = configuration["MicrosoftAppId"];
         }
 
-        [HttpPost]
+        [HttpPost("api/messages")]
         public async Task PostAsync()
         {
             // Delegate the processing of the HTTP POST to the adapter.
             // The adapter will invoke the bot.
             await _adapter.ProcessAsync(Request, Response, _bot);
+        }
+
+        [HttpGet("events/sendback")]
+        public async Task<InvokeResponse> GetTest()
+        {
+            // var conversation = _conversations.Values.Where(c => c.Conversation.Id == "19:f854f14bb6174faebea252e028da8972@thread.v2").FirstOrDefault();
+            var conversation = _conversations.Values.FirstOrDefault();
+
+            if (conversation == null)
+            {
+                _logger.LogInformation("++++++++++++++EVENTS REQUEST Conversation Count: {0} +++++++++++", _conversations.Count);
+                return new InvokeResponse{ Status = 404 };
+            }
+
+            await ((BotFrameworkAdapter)_adapter).ContinueConversationAsync(_appId, conversation, async (context, token) =>
+            {
+                context.Activity.Value = new JObject(
+                    new JProperty("kill_choice", "No one"));
+                context.Activity.ChannelId = conversation.ChannelId;
+
+                await _bot.OnTurnAsync(context, token);
+            }, default(CancellationToken));
+
+            _logger.LogInformation("++++++++++++++EVENTS REQUEST +++++++++++");
+
+            return new InvokeResponse{ Status = 200 };
         }
     }
 }

--- a/mafia-conversation-bot/ConversationData.cs
+++ b/mafia-conversation-bot/ConversationData.cs
@@ -19,5 +19,8 @@ namespace Microsoft.BotBuilderSamples
 
         // Is the current round of game started
         public bool IsGameStarted { get; set; } = false;
+
+        public string MafiaTarget { get; set; }
+        public string DoctorTarget { get; set; }
     }
 }

--- a/mafia-conversation-bot/ConversationData.cs
+++ b/mafia-conversation-bot/ConversationData.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using MafiaCore;
 using System.Collections.Generic;
 
 namespace Microsoft.BotBuilderSamples
@@ -9,10 +10,13 @@ namespace Microsoft.BotBuilderSamples
     public class ConversationData
     {
         /// <summary>
-        /// Map between user ID to userName
+        /// Map between user ID to userName for all users whether they are alive
         /// </summary>
         public Dictionary<string, string> UserProfileMap { get; set; } = new Dictionary<string, string>();
 
+        /// <summary>
+        /// Map between player rolw to a list of active user Ids
+        /// </summary>
         public Dictionary<string, List<string>> RoleToUsers { get; set; } = new Dictionary<string, List<string>>();
 
         public List<string> ActivePlayers { get; set; } = new List<string>();
@@ -22,5 +26,9 @@ namespace Microsoft.BotBuilderSamples
 
         public string MafiaTarget { get; set; }
         public string DoctorTarget { get; set; }
+
+        public string VoteTarget { get; set; }
+
+        public GameState CurrentState { get; set; } = GameState.Unassigned;
     }
 }

--- a/mafia-conversation-bot/Dialogs/CancelAndHelpDialog.cs
+++ b/mafia-conversation-bot/Dialogs/CancelAndHelpDialog.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.BotBuilderSamples
+{
+    public class CancelAndHelpDialog : ComponentDialog
+    {
+        private const string HelpMsgText = "This is the help info for MafiaGame Bot. If you have any question, please contact kunyl@micorosoft.com";
+        private const string CancelMsgText = "Manually Cancel the whole game.";
+        // protected readonly ILogger Logger;
+
+        public CancelAndHelpDialog(string id)
+            : base(id)
+        {
+        }
+
+        protected override async Task<DialogTurnResult> OnContinueDialogAsync(DialogContext innerDc, CancellationToken cancellationToken = default)
+        {
+            var result = await InterruptAsync(innerDc, cancellationToken);
+            if (result != null)
+            {
+                return result;
+            }
+
+            if (innerDc.Context.Activity.Type == ActivityTypes.Event)
+            {
+                Console.WriteLine("++++++++++++++Begin new stack++++++++++");
+                var dialogs = innerDc.Dialogs;
+                var dc = await dialogs.CreateContextAsync(innerDc.Context);
+
+                DialogSet test = dc.Dialogs;
+                if (dc.ActiveDialog == null)
+                {
+                    await dc.BeginDialogAsync(nameof(MainDialog), cancellationToken);
+                }
+                else
+                {
+                    await dc.ContinueDialogAsync(cancellationToken);
+                }
+
+                return await innerDc.BeginDialogAsync(nameof(MainDialog));
+            }
+            
+
+            Console.WriteLine("++++++++++++++++++++++Continue++++++++++");
+            return await base.OnContinueDialogAsync(innerDc, cancellationToken);
+        }
+
+        private async Task<DialogTurnResult> InterruptAsync(DialogContext innerDc, CancellationToken cancellationToken)
+        {
+            if (innerDc.Context.Activity.Type == ActivityTypes.Message && innerDc.Context.Activity.Text != null)
+            {
+                var text = innerDc.Context.Activity.Text.ToLowerInvariant();
+
+                switch (text)
+                {
+                    case "help":
+                    case "?":
+                        var helpMessage = MessageFactory.Text(HelpMsgText, HelpMsgText, InputHints.ExpectingInput);
+                        await innerDc.Context.SendActivityAsync(helpMessage, cancellationToken);
+                        return new DialogTurnResult(DialogTurnStatus.Waiting);
+
+                    case "cancel":
+                    case "quit":
+                        var cancelMessage = MessageFactory.Text(CancelMsgText, CancelMsgText, InputHints.IgnoringInput);
+                        await innerDc.Context.SendActivityAsync(cancelMessage, cancellationToken);
+                        return await innerDc.CancelAllDialogsAsync(cancellationToken);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/mafia-conversation-bot/Dialogs/CancelAndHelpDialog.cs
+++ b/mafia-conversation-bot/Dialogs/CancelAndHelpDialog.cs
@@ -56,12 +56,14 @@ namespace Microsoft.BotBuilderSamples
             {
                 var convStateAccessor = _conversationState.CreateProperty<ConversationData>(nameof(ConversationData));
                 var convInfo = await convStateAccessor.GetAsync(innerDc.Context, () => new ConversationData());
+                /*
                 if (!convInfo.IsGameStarted)
                 {
                     await innerDc.CancelAllDialogsAsync(cancellationToken);
-                    Console.WriteLine("++++++++++++++++++++++InterruptAsync++++++++++" + convInfo.IsGameStarted);
+                    Console.WriteLine("++++++++++++++++++++++InterruptAsync++++++++++");
                     return await innerDc.BeginDialogAsync(nameof(MainDialog));
                 }
+                */
 
                 var text = innerDc.Context.Activity.Text.ToLowerInvariant();
                 switch (text)

--- a/mafia-conversation-bot/Dialogs/DialogHelper.cs
+++ b/mafia-conversation-bot/Dialogs/DialogHelper.cs
@@ -1,0 +1,58 @@
+using MafiaCore;
+using MafiaCore.Players;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Teams;
+using Microsoft.Bot.Schema.Teams;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.BotBuilderSamples
+{
+
+    public class DialogHelper
+    {
+        public static async Task<List<TeamsChannelAccount>> GetPagedMembers(ITurnContext turnContext, CancellationToken cancellationToken)
+        {
+            List<TeamsChannelAccount> members = new List<TeamsChannelAccount>();
+            string continuationToken = null;
+
+            do
+            {
+                var currentPage = await TeamsInfo.GetPagedMembersAsync(turnContext, 100, continuationToken, cancellationToken);
+                continuationToken = currentPage.ContinuationToken;
+                members = members.Concat(currentPage.Members).ToList();
+            }
+            while (continuationToken != null);
+
+            return members;
+        }
+
+        public static ConversationData ConvertConversationState(Game mafiaGame)
+        {
+            ConversationData gameData = new ConversationData();
+
+            gameData.ActivePlayers = mafiaGame.ActivePlayers.Select(p => p.Id).ToList();
+            foreach (KeyValuePair<string, Player> pair in mafiaGame.PlayerMapping)
+            {
+                gameData.UserProfileMap.Add(pair.Key, pair.Value.Name);
+
+                var roleName = pair.Value.Role.ToString();
+                if (!gameData.RoleToUsers.ContainsKey(roleName))
+                {
+                    gameData.RoleToUsers[roleName] = new List<string>();
+                }
+                if (gameData.ActivePlayers.Contains(pair.Key))
+                    gameData.RoleToUsers[roleName].Add(pair.Key);
+            }
+            gameData.IsGameStarted = true;
+            gameData.VoteTarget = mafiaGame.ActivePlayers.FirstOrDefault()?.Vote;
+            gameData.MafiaTarget = mafiaGame.Mafias.FirstOrDefault()?.Target;
+            gameData.DoctorTarget = mafiaGame.Doctors.FirstOrDefault()?.Target;
+            gameData.CurrentState = mafiaGame.CurrentState;
+
+            return gameData;
+        }
+    }
+}

--- a/mafia-conversation-bot/Dialogs/GameRoundDialog.cs
+++ b/mafia-conversation-bot/Dialogs/GameRoundDialog.cs
@@ -111,6 +111,7 @@ namespace Microsoft.BotBuilderSamples
 
             if (stepContext.Result != null)
             {
+                Console.WriteLine("+++++++NightValidationStepAsync: Get result form stepContext+++++++++++");
                 kill_choice = (string)(stepContext.Result as JObject)[KillChoice];
                 doctor_choice = (string)(stepContext.Result as JObject)[DoctorChoice];
             }
@@ -135,6 +136,7 @@ namespace Microsoft.BotBuilderSamples
             convInfo.DoctorTarget = null;
             await convStateAccessor.SetAsync(stepContext.Context, convInfo, cancellationToken);
 
+            stepContext.Values[currentGame] = DialogHelper.ConvertConversationState(mafiaGame);
             if (mafiaGame.CurrentState == GameState.MafiasWon)
             {
                 return await stepContext.EndDialogAsync("Mafia win", cancellationToken);
@@ -145,7 +147,6 @@ namespace Microsoft.BotBuilderSamples
             }
             else
             {
-                stepContext.Values[currentGame] = DialogHelper.ConvertConversationState(mafiaGame);
                 return await stepContext.NextAsync(mafiaGame.Mafias.FirstOrDefault()?.Target, cancellationToken);
             }
         }
@@ -254,7 +255,6 @@ namespace Microsoft.BotBuilderSamples
                 {
                     if (activeMafiaIds.Contains(member.Id))
                     {
-                        Console.WriteLine("+++++++++++should be here");
                         mafias.Add(member);
                     }
                     else if (activeDoctorIds.Contains(member.Id))

--- a/mafia-conversation-bot/Startup.cs
+++ b/mafia-conversation-bot/Startup.cs
@@ -5,9 +5,11 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using System.Collections.Concurrent;
 
 namespace Microsoft.BotBuilderSamples
 {
@@ -37,7 +39,11 @@ namespace Microsoft.BotBuilderSamples
             // Create the Conversation state. (Used by the Dialog system itself.)
             services.AddSingleton<ConversationState>();
 
+            // Create a global hashset for our ConversationReferences
+            services.AddSingleton<ConcurrentDictionary<string, ConversationReference>>();
+
             services.AddSingleton<MainDialog>();
+
             // Create the bot as a transient. In this case the ASP Controller is expecting an IBot.
             services.AddTransient<IBot, DialogAndWelcomeBot<MainDialog>>();
         }


### PR DESCRIPTION
1. Make the night prompt a fake one, which means it sends choice cards to different special roles in one step, and determine if it can move to the next step by "isNightChoiceComplete" in DiaglogBot;
2. Add cancel dialog in case user interruption
3. Add conversation reference for use in individual reply compling